### PR TITLE
make code compatible with python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ nosetests.xml
 .ropeproject/globalnames
 .ropeproject/history
 .ropeproject/objectdb
+.idea

--- a/pymimage/converters/OMEXMLmaker.py
+++ b/pymimage/converters/OMEXMLmaker.py
@@ -266,9 +266,10 @@ class OMEXMLMaker(object):
         self.done = 0
         self.shellrunners = {}
         self.herder = RunnerHerder(3)
-        self.files_to_convert = self.toconvert.keys()
-        self.files_to_convert.sort()
-        for f, f_out in self.toconvert.iteritems():
+        self.files_to_convert = sorted(self.toconvert.keys()) if sys.version_info[0] >= 3 \
+            else self.toconvert.keys().sort()
+
+        for f, f_out in self.toconvert.items() if sys.version_info[0] >= 3 else self.toconvert.iteritems():
             if os.path.isfile(f_out):
                 self.logger.info("%s already converted to %s" % (f, f_out))
             else:
@@ -322,7 +323,7 @@ class OMEXMLMakerQt(OMEXMLMaker):
                 files_converted = QC.pyqtSignal(int)
 
             self.qt_sender = SenderObject()
-        except ImportError, e:
+        except ImportError as e:
             self.logger.error("Cannot import PyQ5! Use the non-Qt class")
             raise e
 

--- a/pymimage/imagemaker.py
+++ b/pymimage/imagemaker.py
@@ -2,39 +2,39 @@ import os
 import hashlib
 import logging
 
-from readers.customreader import CustomReader
-from converters.OMEXMLmaker import OMEXMLMaker
+from pymimage.readers.customreader import CustomReader
+from pymimage.converters.OMEXMLmaker import OMEXMLMaker
+
 
 class ImageMaker(object):
+
     bytes_to_read = 1024**2
     hash_digits = 10
 
     def __init__(self, ome_dir):
         self.ome_dir = ome_dir
-        import readers.LSMreader
-        import readers.OIBreader
-        import readers.VTITIFreader
+        import pymimage.readers.LSMreader
+        import pymimage.readers.OIBreader
+        import pymimage.readers.VTITIFreader
         self.logger = logging.getLogger(__name__)
         self.hash_cache={}
         if not os.path.isdir(self.ome_dir):
             try:
                 os.mkdir(self.ome_dir)
-            except OSError, e:
+            except OSError as e:
                 self.logger.error("OME folder {} does not exist and cannot be created".
                                   format(self.ome_dir))
                 raise e
 
-
     @staticmethod
     def get_hash(filename):
         if os.path.isfile(filename):
-            with open(filename,'rb') as f:
+            with open(filename, 'rb') as f:
                 data = f.read(ImageMaker.bytes_to_read)
                 fhash = hashlib.sha1(data).hexdigest()[:ImageMaker.hash_digits]
                 return fhash
         else:
-            raise IOError("No such file: %s"%filename)
-
+            raise IOError("No such file: %s" % filename)
 
     def check_for_ome(self, file_name, force_reader = None):
         ome_full_name, ome_name = self.get_ome_full_name(file_name)
@@ -80,9 +80,9 @@ class ImageMaker(object):
             converted, failed = ome_maker.convert_all()
             for ome_file in converted:
                 ome_file = self.check_for_ome(file_name)
-                ome_files[file_name]=ome_file
+                ome_files[file_name] = ome_file
             for name in failed:
-                ome_files[file_name]=None
+                ome_files[file_name] = None
         return ome_files
 
     def load_file(self, file_name):

--- a/pymimage/readers/LSMreader.py
+++ b/pymimage/readers/LSMreader.py
@@ -2,11 +2,12 @@ import re
 
 import numpy
 
-from OMEXMLreader import OMEXMLReader
-from customreader import CustomReader
+from pymimage.readers.OMEXMLreader import OMEXMLReader
+from pymimage.readers.customreader import CustomReader
 
 
 class LSMReader(OMEXMLReader, CustomReader):
+
     ftype = "lsm"
 
     def _get_typespecific_extra_info(self):
@@ -48,7 +49,7 @@ class LSMReader(OMEXMLReader, CustomReader):
         self.event_times = []
         for event_no in raw_events.keys():
             self.event_times.append(float(raw_events[event_no]['Time']))
-        print 'events', len(self.event_times)
+        print('events', len(self.event_times))
 
         timestamp_keys = raw_timestamps.keys()
         timestamp_keys.sort()

--- a/pymimage/readers/OIBreader.py
+++ b/pymimage/readers/OIBreader.py
@@ -1,11 +1,12 @@
 import numpy
 
-from OMEXMLreader import OMEXMLReader
-from customreader import CustomReader
+from pymimage.readers.OMEXMLreader import OMEXMLReader
+from pymimage.readers.customreader import CustomReader
 
 
 class OIBReader(OMEXMLReader, CustomReader):
     ftype = ["oib", "oif"]
+
     def _get_typespecific_extra_info(self):
         raw_keys = self.raw_annotation.keys()
         raw_keys.sort()

--- a/pymimage/readers/VTITIFreader.py
+++ b/pymimage/readers/VTITIFreader.py
@@ -1,7 +1,8 @@
 import numpy
 
-from OMEXMLreader import OMEXMLReader
-from customreader import CustomReader
+from pymimage.readers.OMEXMLreader import OMEXMLReader
+from pymimage.readers.customreader import CustomReader
+
 
 class VTITIFReader(OMEXMLReader, CustomReader):
     ftype = "tif"

--- a/pymimage/readers/customreader.py
+++ b/pymimage/readers/customreader.py
@@ -1,18 +1,15 @@
 import logging
 import os
 
-from OMEXMLreader import OMEXMLReader
+from pymimage.readers.OMEXMLreader import OMEXMLReader
 
 class CustomReader(object):
     """Base class for readers that need to do some custom processing of the image data."""
 
-    class __metaclass__(type):
-        def __init__(cls, name, base, attrs):
-            print base
-            if not hasattr(cls, 'registered'):
-                cls.registered = []
-            else:
-                cls.registered.append(cls)
+    registered = []
+
+    def __init__(self, name, base, attrs):
+        self.registered.append(self)
 
     @classmethod
     def get_reader(cls, file_name):
@@ -27,7 +24,7 @@ class CustomReader(object):
             for ftype in reader_types:
                 if ftype == extension:
                     suitable.append(reader)
-        if len(suitable)>1:
+        if len(suitable) > 1:
             message = "More than one reader found for file type {}: {}".\
                     format(extension, ", ".join([cl.__name__ for cl in suitable]))
             logger.warning(message)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+nose
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+inflect

--- a/test/test_reading.py
+++ b/test/test_reading.py
@@ -1,30 +1,35 @@
 import os
+from os.path import join, dirname
+import pytest
 from pymimage.imagemaker import ImageMaker
 from nose.tools import raises
+import tempfile
+
+_filename = __file__
 
 
 def test_hash():
-    filename = os.path.join("test", "data", "Image0035.oib")
+    filename = join(dirname(_filename), "data", "Image0035.oib")
     assert ImageMaker.get_hash(filename) == "e06250156e"
 
 
-class TestOIBConversion():
+class TestOIBConversion:
 
     @classmethod
     def setup_class(cls):
-        "Remove existing file"
-        ome_name = os.path.join("tmp", "e06250156e.ome")
-        try:
-            pass
-            os.remove(ome_name)
-        except OSError:
-            pass
+        cls.filename = join(dirname(_filename), "data", "Image0035.oib")
+        cls.temp_dir = tempfile.TemporaryDirectory()
+        print(cls.temp_dir.name)
+        cls.imaker = ImageMaker(cls.temp_dir.name)
+        cls.ome_name = join(cls.temp_dir.name, "e06250156e.ome")
+        cls.ome_file = cls.imaker.load_file(cls.filename)
 
-    def setup(self):
-        self.filename = os.path.join("test", "data", "Image0035.oib")
-        self.imaker = ImageMaker("tmp")
-        self.ome_name = os.path.join("tmp", "e06250156e.ome")
-        self.ome_file = self.imaker.load_file(self.filename)
+    @classmethod
+    def teardown_class(cls):
+        try:
+            cls.temp_dir.cleanup()
+        except OSError as e:
+            raise e
 
     def test_load(self):
         """test"""
@@ -68,22 +73,42 @@ class TestOIBConversion():
             assert im_data.mean() > 0
 
 
-class TestMissingFileConversion():
+class TestMissingFileConversion:
 
-    def setup(self):
-        self.filename = os.path.join("test", "data", "nosuchfile.oib")
-        self.imaker = ImageMaker("tmp")
+    @classmethod
+    def setup_class(cls):
+        cls.filename = join(dirname(_filename), "data", "nosuchfile.oib")
+        cls.temp_dir = tempfile.TemporaryDirectory()
+        print(cls.temp_dir.name)
+        cls.imaker = ImageMaker(cls.temp_dir.name)
+
+    @classmethod
+    def teardown_class(cls):
+        try:
+            cls.temp_dir.cleanup()
+        except OSError as e:
+            raise e
 
     @raises(IOError)
     def test_load(self):
         self.ome_file = self.imaker.load_file(self.filename)
 
 
-class TestInvalidFileConversion():
+class TestInvalidFileConversion:
 
-    def setup(self):
-        self.filename = os.path.join("test", "data", "invalid.oib")
-        self.imaker = ImageMaker("tmp")
+    @classmethod
+    def setup_class(cls):
+        cls.filename = join(dirname(_filename), "data", "invalid.oib")
+        cls.temp_dir = tempfile.TemporaryDirectory()
+        print(cls.temp_dir.name)
+        cls.imaker = ImageMaker(cls.temp_dir.name)
+
+    @classmethod
+    def teardown_class(cls):
+        try:
+            cls.temp_dir.cleanup()
+        except OSError as e:
+            raise e
 
     def test_load(self):
         self.ome_file = self.imaker.load_file(self.filename)


### PR DESCRIPTION
* fix python 3 requirements for print, sort and except
* use full module path in imports
* update imports to python 3 versions
* create requirement files
* improve temporary directory management
* some PEP8 adjustments